### PR TITLE
Fix incompatible new SFML version error

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,13 @@
   "dependencies": [
     "benchmark",
     "imgui-sfml",
-    "sfml",
     "boost-type-index"
+  ],
+  "builtin-baseline": "cc1ef7a97b165d865607b559f107b12a621e64c1",
+  "overrides": [
+    {
+      "name": "sfml",
+      "version": "2.6.2"
+    }
   ]
 }


### PR DESCRIPTION
![happy cat](https://media1.tenor.com/m/CarV7GDhiwQAAAAC/yippee-cat.gif)

Finally, the new baseline to enforce fixed version of SFML works in Windows. However, if vcpkg was installed long time ago,  an update is required. Otherwise, cmake won't compile. Here are the steps  
```bash
cd path/to/vcpkg
git fetch origin
git pull origin master
.\bootstrap-vcpkg.bat # For Windows
`./bootstrap-vcpkg.sh # For Linux/macOS`
```
